### PR TITLE
Add AI skill for quarkus-cache

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -131,8 +131,8 @@
         <infinispan.version>16.0.9</infinispan.version>
         <infinispan.protostream.version>6.0.6</infinispan.protostream.version>
         <caffeine.version>3.2.3</caffeine.version>
-        <netty.version>4.1.132.Final</netty.version>
-        <brotli4j.version>1.16.0</brotli4j.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <mutiny.version>3.2.0</mutiny.version>

--- a/extensions/cache/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/cache/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,99 @@
+## Key Patterns
+
+### Annotation-based caching
+
+Apply `@CacheResult`, `@CacheInvalidate`, and `@CacheInvalidateAll` to **non-private** methods of CDI beans. The `cacheName` is required on every annotation.
+
+```java
+@ApplicationScoped
+public class MyService {
+
+    @CacheResult(cacheName = "my-cache")
+    public ExpensiveResult compute(String key) {
+        return doExpensiveWork(key);
+    }
+
+    @CacheInvalidate(cacheName = "my-cache")
+    public void invalidateOne(String key) {
+        // body can be empty — invalidation is handled by the interceptor
+    }
+
+    @CacheInvalidateAll(cacheName = "my-cache")
+    public void invalidateAll() {
+    }
+}
+```
+
+### Composite cache keys
+
+When a method has multiple parameters, **all unannotated parameters** form the cache key. Use `@CacheKey` to select specific parameters. Multiple `@CacheKey` parameters create a `CompositeCacheKey` — **parameter order matters** and must match between `@CacheResult` and `@CacheInvalidate`:
+
+```java
+@CacheResult(cacheName = "weather")
+public Weather get(@CacheKey String city, @CacheKey String units, RequestContext ctx) {
+    // key = CompositeCacheKey(city, units) — ctx is excluded
+}
+
+@CacheInvalidate(cacheName = "weather")
+public void invalidate(@CacheKey String city, @CacheKey String units) {
+    // MUST use same parameter order as @CacheResult
+}
+```
+
+### Programmatic API
+
+Inject a cache by name with `@CacheName` or look it up via `CacheManager`:
+
+```java
+@CacheName("my-cache")
+Cache cache;
+
+@Inject
+CacheManager cacheManager; // getCacheNames() returns Collection<String>, not Set
+```
+
+Access the underlying Caffeine cache for advanced operations:
+
+```java
+CaffeineCache caffeine = cache.as(CaffeineCache.class);
+Set<Object> keys = caffeine.keySet();
+CompletableFuture<Object> value = caffeine.getIfPresent(key);
+
+// Programmatic put and invalidation
+caffeine.put(key, CompletableFuture.completedFuture(value));
+cache.invalidateAll().await().indefinitely();
+cache.invalidate(key).await().indefinitely();
+```
+
+## Common Pitfalls
+
+- **Self-invocation does not trigger caching.** Calling a `@CacheResult` method from within the same bean bypasses the interceptor. Always call cached methods through the CDI proxy (from another bean or via `self` injection).
+- **`CacheManager.getCacheNames()` returns `Collection<String>`**, not `Set<String>`. Using `Set` causes a compilation error.
+- **`@CacheInvalidate` method bodies can be empty.** The invalidation happens in the interceptor, not in your code.
+- **Cache key mismatch silently fails.** If `@CacheInvalidate` parameters don't match the `@CacheResult` key structure (same types, same order), invalidation has no effect with no error.
+
+## Testing
+
+Use `@QuarkusTest` normally — caching is enabled by default in all profiles. To verify caching behavior, use the programmatic API:
+
+```java
+@QuarkusTest
+class CacheTest {
+
+    @CacheName("my-cache")
+    Cache cache;
+
+    @BeforeEach
+    void clearCache() {
+        cache.invalidateAll().await().indefinitely();
+    }
+
+    @Test
+    void verifyCacheHit() {
+        // call the service twice, assert same result
+        // verify key exists: cache.as(CaffeineCache.class).keySet()
+    }
+}
+```
+
+Prefer asserting on cache contents (`keySet()`, `getIfPresent()`) over timing-based assertions, which are flaky in CI.

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
@@ -26,12 +26,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.impl.NoStackTraceException;
 
 public class ErrorDuringStreamingTestCase {
 
@@ -92,7 +92,13 @@ public class ErrorDuringStreamingTestCase {
                                     response
                                             .handler(bodyConsumer::accept)
                                             .exceptionHandler(latch::completeExceptionally)
-                                            .end(latch::complete);
+                                            .end().onComplete(ar -> {
+                                                if (ar.failed()) {
+                                                    latch.completeExceptionally(ar.cause());
+                                                } else {
+                                                    latch.complete(null);
+                                                }
+                                            });
                                 });
 
                     }
@@ -107,7 +113,7 @@ public class ErrorDuringStreamingTestCase {
             return Multi.createFrom().emitter(emitter -> {
                 emit(emitter);
                 if (fail) {
-                    throw new NoStackTraceException("dummy");
+                    emitter.fail(new VertxException("dummy"));
                 } else {
                     emit(emitter);
                     emitter.complete();

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.2.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Adds a `quarkus-skill.md` for the cache extension covering annotation-based caching patterns,
composite cache keys, programmatic CaffeineCache access, and testing guidance.

Created using the [skill factory process](https://github.com/quarkusio/quarkus-agent-mcp/blob/main/docs/creating-extension-skills.md):
a Sonnet tester agent built a weather caching app without any skill and reported significant
friction around composite cache key ordering, CacheManager API types (`Collection` vs `Set`),
and programmatic cache inspection. A skill was authored addressing these gaps, then validated
by a fresh Sonnet agent that completed the same task with an "excellent" rating (10/10 tests
passing, estimated 30-45 min saved).

Closes #3