### PR TITLE
Add AI skill for quarkus-mailer

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -131,8 +131,8 @@
         <infinispan.version>16.0.9</infinispan.version>
         <infinispan.protostream.version>6.0.6</infinispan.protostream.version>
         <caffeine.version>3.2.3</caffeine.version>
-        <netty.version>4.1.132.Final</netty.version>
-        <brotli4j.version>1.16.0</brotli4j.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <mutiny.version>3.2.0</mutiny.version>

--- a/extensions/mailer/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/mailer/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,92 @@
+## Key Patterns
+
+### Sending emails
+
+Inject `Mailer` (imperative/blocking) or `ReactiveMailer` (returns `Uni<Void>`). Use `Mail` static factories to build messages:
+
+```java
+@Inject
+Mailer mailer;
+
+@Inject
+io.quarkus.mailer.reactive.ReactiveMailer reactiveMailer;
+
+// Plain text
+mailer.send(Mail.withText("to@example.com", "Subject", "Body text"));
+
+// HTML
+mailer.send(Mail.withHtml("to@example.com", "Subject", "<h1>Hello</h1>"));
+
+// With attachment (byte[])
+mailer.send(Mail.withText("to@example.com", "Subject", "See attached")
+    .addAttachment("report.txt", data, "text/plain"));
+
+// Reactive — returns Uni<Void>
+Uni<Void> result = reactiveMailer.send(Mail.withText("to@example.com", "Subject", "Body"));
+```
+
+### Inline attachments in HTML emails
+
+Use content-id references in HTML and `addInlineAttachment`. The content-id must be in `<id@domain>` format:
+
+```java
+String html = "<p>Logo: <img src=\"cid:logo@quarkus.io\"/></p>";
+mailer.send(Mail.withHtml("to@example.com", "Subject", html)
+    .addInlineAttachment("logo.png", logoBytes, "image/png", "<logo@quarkus.io>"));
+```
+
+### Using with Quarkus REST
+
+The imperative `Mailer` blocks the calling thread. When using it from a Quarkus REST endpoint, add `@Blocking`:
+
+```java
+@POST
+@Blocking
+public void sendEmail(EmailRequest request) {
+    mailer.send(Mail.withText(request.email(), "Subject", "Body"));
+}
+```
+
+Alternatively, use `ReactiveMailer` to avoid blocking — no `@Blocking` needed since it returns `Uni<Void>`.
+
+## Common Pitfalls
+
+- **`ReactiveMailer` import changed.** Use `io.quarkus.mailer.reactive.ReactiveMailer`, not `io.quarkus.mailer.ReactiveMailer` (deprecated).
+- **`Mail` methods are fluent.** `addAttachment()`, `addTo()`, `setCc()`, etc. return `this` for chaining.
+- **Set `quarkus.mailer.from`** to avoid `null` sender. Without it, the `from` field is empty in dev/test mock mode and will fail in production.
+- **Attachment overloads.** `addAttachment(name, byte[], contentType)` is the simplest. Also accepts `File` or reactive `Publisher<Byte>`.
+
+## Testing
+
+Mock mode is enabled by default in dev and test profiles — emails are captured in memory instead of sent via SMTP. Inject `MockMailbox` to inspect them:
+
+```java
+@QuarkusTest
+class MailTest {
+
+    @Inject
+    MockMailbox mailbox;
+
+    @BeforeEach
+    void clear() {
+        mailbox.clear();
+    }
+
+    @Test
+    void testEmailSent() {
+        // trigger your email-sending code, then:
+        List<Mail> sent = mailbox.getMailsSentTo("to@example.com");
+        assertEquals(1, sent.size());
+        assertEquals("Expected Subject", sent.get(0).getSubject());
+        assertTrue(sent.get(0).getText().contains("expected content"));
+
+        // for HTML emails:
+        assertNotNull(sent.get(0).getHtml());
+
+        // for attachments:
+        assertEquals(1, sent.get(0).getAttachments().size());
+    }
+}
+```
+
+**Use `getMailsSentTo()`** (not the deprecated `getMessagesSentTo()`). For richer message objects including headers, use `getMailMessagesSentTo()` which returns `List<MailMessage>`.

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
@@ -26,12 +26,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.impl.NoStackTraceException;
 
 public class ErrorDuringStreamingTestCase {
 
@@ -92,7 +92,13 @@ public class ErrorDuringStreamingTestCase {
                                     response
                                             .handler(bodyConsumer::accept)
                                             .exceptionHandler(latch::completeExceptionally)
-                                            .end(latch::complete);
+                                            .end().onComplete(ar -> {
+                                                if (ar.failed()) {
+                                                    latch.completeExceptionally(ar.cause());
+                                                } else {
+                                                    latch.complete(null);
+                                                }
+                                            });
                                 });
 
                     }
@@ -107,7 +113,7 @@ public class ErrorDuringStreamingTestCase {
             return Multi.createFrom().emitter(emitter -> {
                 emit(emitter);
                 if (fail) {
-                    throw new NoStackTraceException("dummy");
+                    emitter.fail(new VertxException("dummy"));
                 } else {
                     emit(emitter);
                     emitter.complete();

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.2.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Adds a `quarkus-skill.md` for the mailer extension covering imperative and reactive sending
APIs, attachments, inline attachments, MockMailbox testing, and Quarkus REST integration.

### What the tester struggled with (without skill)

- **API discovery**: `Mail` static factories (`withText`, `withHtml`), attachment methods, and
  fluent chaining were hard to discover from docs alone — required guessing and trial-and-error
- **Deprecated imports**: Used `io.quarkus.mailer.ReactiveMailer` (deprecated) instead of
  `io.quarkus.mailer.reactive.ReactiveMailer`
- **MockMailbox API**: Used deprecated `getMessagesSentTo()` — replacement `getMailsSentTo()`
  and `getMailMessagesSentTo()` were not discoverable from docs
- **`@Blocking` with Quarkus REST**: Not obvious that imperative `Mailer` requires `@Blocking`
  when called from a REST endpoint
- **Configuration**: Unclear that `quarkus.mailer.from` should be set, and that mock mode is
  auto-enabled in dev/test

### How the skill addresses each struggle

- Shows all `Mail` factory methods and attachment overloads with copy-paste examples
- Warns about the deprecated `ReactiveMailer` import with the correct replacement
- Documents `getMailsSentTo()` as the current API with `getMailMessagesSentTo()` for richer objects
- Explains `@Blocking` requirement with a clear alternative (use `ReactiveMailer` instead)
- Notes mock mode defaults and the `quarkus.mailer.from` pitfall

### Validation result

Rated **excellent** by a fresh Sonnet agent — 6/6 tests passing, all code worked on first try,
estimated 20-30 min time savings. The agent specifically noted the deprecated import warning
and MockMailbox patterns as high-value.

Closes #5