### PR TITLE
Add AI skill for quarkus-qute

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -131,8 +131,8 @@
         <infinispan.version>16.0.9</infinispan.version>
         <infinispan.protostream.version>6.0.6</infinispan.protostream.version>
         <caffeine.version>3.2.3</caffeine.version>
-        <netty.version>4.1.132.Final</netty.version>
-        <brotli4j.version>1.16.0</brotli4j.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <mutiny.version>3.2.0</mutiny.version>

--- a/extensions/qute/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/qute/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,112 @@
+## Key Patterns
+
+### Type-safe templates with @CheckedTemplate
+
+Declare templates as `static native` methods inside a `@CheckedTemplate`-annotated nested class. Method parameters become template parameters, validated at build time:
+
+```java
+@Path("products")
+public class ProductResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance list(List<Product> products);
+        static native TemplateInstance detail(Product product);
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance list() {
+        return Templates.list(service.findAll());
+    }
+}
+```
+
+Alternative: use a Java record that implements `TemplateInstance`:
+
+```java
+record Hello(String name) implements TemplateInstance {}
+// template: templates/Hello.html
+```
+
+### Template file path resolution
+
+Templates go in `src/main/resources/templates/`. The path is derived from the class structure:
+
+| Declaration | Method | Template path |
+|---|---|---|
+| Nested `Templates` in `ProductResource` | `list()` | `templates/ProductResource/list.html` |
+| Top-level class | `hello()` | `templates/hello.html` |
+| `@CheckedTemplate(basePath = "items")` | `detail()` | `templates/items/detail.html` |
+
+Use `@CheckedTemplate(defaultName = CheckedTemplate.HYPHENATED_ELEMENT_NAME)` to convert camelCase method names to hyphenated file names (e.g., `productList()` → `product-list.html`).
+
+### Template syntax quick reference
+
+```html
+{name}                          <!-- expression -->
+{product.name}                  <!-- property access -->
+{#for item in items}...{/for}   <!-- loop -->
+{#for item in items}{item_count}{/for}  <!-- 1-based index -->
+{#if condition}...{#else}...{/if}       <!-- conditional -->
+{#let x = expr}...{/let}               <!-- local variable -->
+{item.formattedPrice}           <!-- template extension method -->
+{item ?: 'default'}             <!-- default value for null -->
+```
+
+### Template extension methods
+
+Add computed properties to any type using `@TemplateExtension`. The first parameter is the target type:
+
+```java
+@TemplateExtension
+static class ProductExtensions {
+    static String formattedPrice(Product product) {
+        return String.format("$%.2f", product.price());
+    }
+}
+```
+
+In templates: `{product.formattedPrice}` — no parentheses, looks like a property.
+
+## Common Pitfalls
+
+- **Template path must match the class/method structure exactly.** For a nested `Templates` class inside `ProductResource`, templates go in `templates/ProductResource/`, not `templates/`. Build fails if the file is missing.
+- **Return `TemplateInstance`, not `String`.** Quarkus REST automatically renders `TemplateInstance` return values — do not call `.render()` in the endpoint.
+- **Template expressions are type-checked by default.** Undefined properties cause a build error. Use `@TemplateData` on types that don't have public getters, or disable with `@CheckedTemplate(requireTypeSafeExpressions = false)`.
+- **`{#for}` uses `in`, not `:`.** The syntax is `{#for item in items}`, not `{#for item : items}`.
+
+## Testing
+
+Test template rendering via HTTP endpoints with REST-assured:
+
+```java
+@QuarkusTest
+class ProductResourceTest {
+
+    @Test
+    void testListPage() {
+        given()
+            .when().get("/products")
+            .then()
+            .statusCode(200)
+            .body(containsString("Product Name"))
+            .body(containsString("On Sale!"));
+    }
+}
+```
+
+For unit-testing templates directly, inject `Engine` and render manually:
+
+```java
+@Inject
+Engine engine;
+
+@Test
+void testTemplate() {
+    String result = engine.getTemplate("ProductResource/list")
+        .data("products", List.of(product))
+        .render();
+    assertTrue(result.contains("expected"));
+}
+```

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
@@ -26,12 +26,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.impl.NoStackTraceException;
 
 public class ErrorDuringStreamingTestCase {
 
@@ -92,7 +92,13 @@ public class ErrorDuringStreamingTestCase {
                                     response
                                             .handler(bodyConsumer::accept)
                                             .exceptionHandler(latch::completeExceptionally)
-                                            .end(latch::complete);
+                                            .end().onComplete(ar -> {
+                                                if (ar.failed()) {
+                                                    latch.completeExceptionally(ar.cause());
+                                                } else {
+                                                    latch.complete(null);
+                                                }
+                                            });
                                 });
 
                     }
@@ -107,7 +113,7 @@ public class ErrorDuringStreamingTestCase {
             return Multi.createFrom().emitter(emitter -> {
                 emit(emitter);
                 if (fail) {
-                    throw new NoStackTraceException("dummy");
+                    emitter.fail(new VertxException("dummy"));
                 } else {
                     emit(emitter);
                     emitter.complete();

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.2.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Adds a `quarkus-skill.md` for the Qute templating extension covering type-safe templates,
template file path resolution, template syntax, extension methods, and testing patterns.

### What the tester struggled with (without skill)

- **Template file location/naming**: Required 3 separate doc searches to understand that
  `ProductResource.Templates.list()` maps to `templates/ProductResource/list.html`. The path
  resolution rules (nested class → enclosing class name as subdirectory) were non-obvious.
- **Template syntax discovery**: Searching for "for loop" didn't surface Qute's `{#for item in items}`
  syntax — needed Qute-specific search terms.
- **`{#for}` uses `in` not `:`**: Java developers instinctively write `{#for item : items}`.
- **Returning `TemplateInstance`**: Not immediately clear that Quarkus REST auto-renders it —
  some developers call `.render()` manually.

### How the skill addresses each struggle

- Includes a clear path resolution table mapping class structure → template file paths
- Provides a template syntax quick reference with all common constructs
- Explicitly warns about `in` vs `:` in the pitfalls section
- Documents that `TemplateInstance` return values are auto-rendered by Quarkus REST
- Shows `@TemplateExtension` pattern with clear "looks like a property" explanation

### Validation result

Rated **excellent** by a fresh Sonnet agent — 8/8 tests passing on first run. The agent noted
the path resolution table and syntax reference as the most valuable parts, estimating 4-6x
faster development compared to documentation searching alone.

Closes #7