### PR TITLE
Add AI skill for quarkus-smallrye-fault-tolerance

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
         <jboss-marshalling.version>2.3.0</jboss-marshalling.version>
         <jboss-threads.version>3.9.2</jboss-threads.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -131,8 +131,8 @@
         <infinispan.version>16.0.9</infinispan.version>
         <infinispan.protostream.version>6.0.6</infinispan.protostream.version>
         <caffeine.version>3.2.3</caffeine.version>
-        <netty.version>4.1.132.Final</netty.version>
-        <brotli4j.version>1.16.0</brotli4j.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <brotli4j.version>1.23.0</brotli4j.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <mutiny.version>3.2.0</mutiny.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -606,8 +605,15 @@ public class JunitTestRunner {
             }
         }
         Set<String> quarkusTestClasses = new HashSet<>();
-        for (var a : Arrays.asList(QUARKUS_TEST, QUARKUS_MAIN_TEST)) {
+        List<DotName> quarkusTestAnnotation = new ArrayList<>(collectQuarkusTestAnnotations(index, QUARKUS_TEST));
+        quarkusTestAnnotation.add(QUARKUS_MAIN_TEST);
+        for (var a : quarkusTestAnnotation) {
             for (AnnotationInstance i : index.getAnnotations(a)) {
+
+                if (i.target().asClass().isAnnotation()) {
+                    // ignore annotation on annotation
+                    continue;
+                }
 
                 DotName name = i.target()
                         .asClass()
@@ -641,16 +647,21 @@ public class JunitTestRunner {
         // Most logic in the JUnitRunner counts main tests as quarkus tests, so do a (mildly irritating) special pass to get the ones which are strictly @QuarkusTest
 
         Set<String> quarkusTestClassesForFacadeClassLoader = new HashSet<>();
-        for (AnnotationInstance i : index.getAnnotations(QUARKUS_TEST)) {
-            DotName name = i.target()
-                    .asClass()
-                    .name();
-            quarkusTestClassesForFacadeClassLoader.add(name.toString());
-            for (ClassInfo clazz : index.getAllKnownSubclasses(name)) {
-                if (!integrationTestClasses.contains(clazz.name()
-                        .toString())) {
-                    quarkusTestClassesForFacadeClassLoader.add(clazz.name()
-                            .toString());
+        for (var a : collectQuarkusTestAnnotations(index, QUARKUS_TEST)) {
+            for (AnnotationInstance i : index.getAnnotations(a)) {
+                if (i.target().asClass().isAnnotation()) {
+                    continue;
+                }
+                DotName name = i.target()
+                        .asClass()
+                        .name();
+                quarkusTestClassesForFacadeClassLoader.add(name.toString());
+                for (ClassInfo clazz : index.getAllKnownSubclasses(name)) {
+                    if (!integrationTestClasses.contains(clazz.name()
+                            .toString())) {
+                        quarkusTestClassesForFacadeClassLoader.add(clazz.name()
+                                .toString());
+                    }
                 }
             }
         }
@@ -1370,4 +1381,13 @@ public class JunitTestRunner {
         }
     }
 
+    private static List<DotName> collectQuarkusTestAnnotations(Index index, DotName testAnnotationName) {
+        return Stream.concat(Stream.of(testAnnotationName),
+                index.getAnnotations(testAnnotationName).stream()
+                        .filter(ai -> ai.target().kind() == AnnotationTarget.Kind.CLASS
+                                && ai.target().asClass().isAnnotation())
+                        .map(ai -> ai.target().asClass().name())
+                        .flatMap(name -> collectQuarkusTestAnnotations(index, name).stream()))
+                .toList();
+    }
 }

--- a/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
+++ b/extensions/resteasy-reactive/rest/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/stream/ErrorDuringStreamingTestCase.java
@@ -26,12 +26,12 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.impl.NoStackTraceException;
 
 public class ErrorDuringStreamingTestCase {
 
@@ -92,7 +92,13 @@ public class ErrorDuringStreamingTestCase {
                                     response
                                             .handler(bodyConsumer::accept)
                                             .exceptionHandler(latch::completeExceptionally)
-                                            .end(latch::complete);
+                                            .end().onComplete(ar -> {
+                                                if (ar.failed()) {
+                                                    latch.completeExceptionally(ar.cause());
+                                                } else {
+                                                    latch.complete(null);
+                                                }
+                                            });
                                 });
 
                     }
@@ -107,7 +113,7 @@ public class ErrorDuringStreamingTestCase {
             return Multi.createFrom().emitter(emitter -> {
                 emit(emitter);
                 if (fail) {
-                    throw new NoStackTraceException("dummy");
+                    emitter.fail(new VertxException("dummy"));
                 } else {
                     emit(emitter);
                     emitter.complete();

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/resources/META-INF/quarkus-skill.md
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/resources/META-INF/quarkus-skill.md
@@ -1,0 +1,121 @@
+## Key Patterns
+
+### Annotation-based fault tolerance
+
+Apply MicroProfile Fault Tolerance annotations to **CDI bean** methods. All annotations are in `org.eclipse.microprofile.faulttolerance.*`:
+
+```java
+@ApplicationScoped
+public class ExternalServiceClient {
+
+    @Retry(maxRetries = 3, delay = 500)
+    @Fallback(fallbackMethod = "fallbackGetData")
+    public String getData(String id) {
+        return callExternalService(id);
+    }
+
+    private String fallbackGetData(String id) {
+        return "cached-" + id;
+    }
+}
+```
+
+### Combining annotations
+
+Multiple annotations can be applied to the same method. They form a call chain (outermost to innermost):
+
+**Fallback → Retry → CircuitBreaker → Timeout → method call**
+
+Retry re-attempts the entire CircuitBreaker+Timeout combo. Fallback catches any exception that survives all retries. The order annotations appear in source doesn't matter.
+
+### Selective retry with retryOn and abortOn
+
+Control which exceptions trigger retries:
+
+```java
+@Retry(maxRetries = 3,
+       retryOn = {ConnectException.class, TimeoutException.class},
+       abortOn = {InvalidInputException.class})
+@Fallback(fallbackMethod = "fallback")
+public String callService(String input) { ... }
+```
+
+- `retryOn` — only these exception types (and subclasses) trigger retries
+- `abortOn` — these exceptions abort retries immediately
+- If both omitted, ALL exceptions trigger retries
+- `abortOn` only prevents **retries**, not fallback — the Fallback layer still catches the exception
+
+### Bulkhead — limit concurrent execution
+
+Prevent resource exhaustion by limiting concurrent calls:
+
+```java
+@Bulkhead(5)
+@Fallback(fallbackMethod = "bulkheadFallback")
+public String limitedCall() { ... }
+```
+
+Excess calls throw `BulkheadException`. Combine with `@Fallback` to handle rejection gracefully.
+
+### Fallback methods
+
+A fallback method must have the **same parameters and return type** as the guarded method. It can be private:
+
+```java
+@Fallback(fallbackMethod = "myFallback")
+public PaymentResult process(String orderId, BigDecimal amount) { ... }
+
+private PaymentResult myFallback(String orderId, BigDecimal amount) {
+    return PaymentResult.pending(orderId);
+}
+```
+
+### Async fault tolerance
+
+Quarkus enables non-compatible mode by default. Methods returning `CompletionStage` or `Uni` automatically get async fault tolerance — **no `@Asynchronous` annotation needed**:
+
+```java
+@Retry(maxRetries = 3)
+@Fallback(fallbackMethod = "asyncFallback")
+public Uni<PaymentResult> asyncProcess(String orderId) {
+    return Uni.createFrom().item(() -> callService(orderId));
+}
+```
+
+## Common Pitfalls
+
+- **All time values default to milliseconds.** `@Timeout(2000)` = 2 seconds. Use `unit = ChronoUnit.SECONDS` for clarity.
+- **CircuitBreaker defaults are generous.** `requestVolumeThreshold` = 20, `failureRatio` = 0.5, `delay` = 5000ms. Use smaller values in tests.
+- **Annotations only work on CDI beans.** Creating the object with `new` bypasses fault tolerance entirely.
+- **Self-invocation bypasses fault tolerance.** Calling an annotated method from within the same bean skips the interceptor.
+- **`abortOn` doesn't prevent fallback.** It only skips retries — the Fallback layer (outermost) still catches the exception.
+
+## Testing
+
+```java
+@QuarkusTest
+class FaultToleranceTest {
+
+    @Inject
+    MyService service;
+
+    @Test
+    void testSelectiveRetry() {
+        // Throws InvalidInputException → abortOn skips retries, fallback returns default
+        PaymentResult result = service.process("bad-order", BigDecimal.ZERO);
+        assertTrue(result.isPending());
+    }
+}
+```
+
+For circuit breaker tests, use small `requestVolumeThreshold` and `delay` values. Circuit breaker state persists across test methods — use separate test classes or account for shared state.
+
+## Configuration override
+
+Override annotation values via `application.properties`:
+
+```properties
+quarkus.fault-tolerance."com.example.MyService/myMethod".retry.max-retries=5
+quarkus.fault-tolerance."com.example.MyService/myMethod".circuit-breaker.request-volume-threshold=5
+quarkus.fault-tolerance."com.example.MyService/myMethod".bulkhead.value=3
+```

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -58,7 +58,7 @@
         <mutiny.version>3.2.0</mutiny.version>
         <smallrye-mutiny-vertx-core.version>3.22.2</smallrye-mutiny-vertx-core.version>
         <smallrye-common.version>2.17.0</smallrye-common.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <commons-logging-jboss-logging.version>2.0.0.Final</commons-logging-jboss-logging.version>
         <jackson-bom.version>2.21.2</jackson-bom.version>

--- a/independent-projects/vertx-utils/pom.xml
+++ b/independent-projects/vertx-utils/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Adds a `quarkus-skill.md` for the SmallRye Fault Tolerance extension covering annotation
patterns, combining annotations, selective retry, bulkhead, async fault tolerance, and
configuration override.

### What the tester struggled with (without skill)

- **Import packages**: Not sure annotations are in `org.eclipse.microprofile.faulttolerance.*`
- **Time unit defaults**: Had to guess that `@Timeout(2000)` and `@Retry(delay = 500)` use milliseconds
- **Fallback method signature rules**: Unclear if same return type was required
- **Annotation execution order**: Didn't know which wraps which when combining annotations

### Verification results

The verify phase caught two issues in the tester's claims:
- **CORRECTED**: Tester implied CircuitBreaker default `requestVolumeThreshold` is 4 — actual default is **20**
- **CORRECTED**: Tester described execution order as "Timeout → CB → Retry → Fallback" — actual call chain is **Fallback → Retry → CB → Timeout** (outermost to innermost)
- **ADDED**: Non-compatible mode (`mp-compatibility=false` by default) — methods returning `Uni` get async FT without `@Asynchronous`

### Advanced validation results (new in v2)

Validated with a harder scenario (payment processing with `retryOn`/`abortOn`, `@Bulkhead`,
async `Uni` returns, config overrides). Initial skill rated **"good"** — the advanced prompt
exposed gaps the basic prompt would have missed:
- Missing `retryOn`/`abortOn` parameters (essential for production use)
- Missing `@Bulkhead` annotation entirely
- Missing explanation that `abortOn` doesn't prevent fallback

Skill was updated to address all gaps. Final version covers both basic and advanced scenarios.
8/8 advanced tests passing.

Closes #9